### PR TITLE
Implement #6 build part

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -63,6 +63,8 @@ and StopArguments =
             | Version _ -> "wsfscservice version. If empty all running instances"
             | Force -> "kills the service instead of sending stop signal"
 
+type ArgsType = {args: string array}
+
 [<EntryPoint>]
 let main argv =
     let parser = ArgumentParser.Create<Argument>(programName = "dotnet-ws.exe", helpTextMessage = "dotnet-ws is a dotnet tool for WebSharper", checkStructure = true)

--- a/Program.fs
+++ b/Program.fs
@@ -63,8 +63,6 @@ and StopArguments =
             | Version _ -> "wsfscservice version. If empty all running instances"
             | Force -> "kills the service instead of sending stop signal"
 
-type ArgsType = {args: string array}
-
 [<EntryPoint>]
 let main argv =
     let parser = ArgumentParser.Create<Argument>(programName = "dotnet-ws.exe", helpTextMessage = "dotnet-ws is a dotnet tool for WebSharper", checkStructure = true)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ SUBCOMMANDS:
     stop <options>        Sends a stop signal for the wsfscservice with the given version. If no version given it's
                           all running instances. If --force given kills the process instead of stop signal.
     list                  Lists running wsfscservice versions.
+    build                 Build WebSharper project in the current folder. Using cached build information where
+                          possible.
 
     Use 'dotnet-ws.exe <subcommand> --help' for additional information.
 

--- a/WebSharper.Compiler/WebSharper.Compiler.fsproj
+++ b/WebSharper.Compiler/WebSharper.Compiler.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarnOn>3390;$(WarnOn)</WarnOn>
+    <NoWarn>44</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WebSharper.Compiler/WsFscServiceCommon.fs
+++ b/WebSharper.Compiler/WsFscServiceCommon.fs
@@ -1,6 +1,8 @@
 ﻿module WebSharper.Compiler.WsFscServiceCommon
 
 open System.Text
+open System.IO.Pipes
+open System.Runtime.Serialization.Formatters.Binary
 
 type ArgsType = {args: string array}
 
@@ -14,3 +16,21 @@ let hashPath (fullPath: string) =
     (System.Text.StringBuilder(), data)
     ||> Array.fold (fun sb b -> sb.Append(b.ToString("x2")))
     |> string
+
+let readingMessages (pipe: PipeStream) (handleMessage: obj -> Async<'a option>) = 
+    let rec readingMessage() =
+        async {
+            let bf = new BinaryFormatter()
+            try
+                let deserializedMessage = bf.Deserialize(pipe)
+                let! finish = handleMessage deserializedMessage
+                match finish with
+                | Some _ -> return finish
+                | None -> return! readingMessage()
+            with
+            | :? System.Runtime.Serialization.SerializationException ->
+                return None
+            | _ ->
+                return! readingMessage()
+        }
+    readingMessage ()

--- a/dotnet-ws.fsproj
+++ b/dotnet-ws.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>dotnet_ws</RootNamespace>
     <WarnOn>3390;$(WarnOn)</WarnOn>
+    <NoWarn>44</NoWarn>
     <PackAsTool>true</PackAsTool>
     <PackageType>DotnetTool</PackageType>
     <ToolCommandName>dotnet-ws</ToolCommandName>


### PR DESCRIPTION
* Support for `[|"compile:xy"|]` message. 
* Cache invalidation removes auto buildable project from `Dictionary`.
* All wsfscprocesses are trying to build